### PR TITLE
Creating infrastructure handler

### DIFF
--- a/artifacts/test-first-graph.yaml
+++ b/artifacts/test-first-graph.yaml
@@ -1,0 +1,98 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: graph
+  labels:
+    name: graph
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: graph
+  labels:
+    app: nginx
+    ambassador: polycubed
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 32333
+    name: app
+  - port: 9000
+    targetPort: 9000
+    nodePort: 32334
+    name: ambassador
+  clusterIP: 10.96.24.24
+  selector:
+    app: nginx
+    ambassador: polycubed
+---
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: polycubed-ambassador
+  namespace: graph
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+      ambassador: polycubed
+  replicas: 2 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: nginx
+        ambassador: polycubed
+    spec:
+    #serviceAccountName: polycube
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80
+      - name: polycubed
+        image: k8sfirewall/firewall:astrid
+        imagePullPolicy: Always
+        command: ["polycubed", "--loglevel=DEBUG", "--addr=0.0.0.0", "--logfile=/host/var/log/pcn_k8s"]
+        volumeMounts:
+        - name: lib-modules
+          mountPath: /lib/modules
+        - name: usr-src
+          mountPath: /usr/src
+        - name: cni-path
+          mountPath: /host/opt/cni/bin
+        - name: etc-cni-netd
+          mountPath: /host/etc/cni/net.d
+        - name: var-log
+          mountPath: /host/var/log
+        securityContext:
+          privileged: true
+        ports:
+          - name: polycubed
+            containerPort: 9000
+        terminationMessagePolicy: FallbackToLogsOnError
+        #restartPolicy: Never
+      volumes:
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: cni-path
+        hostPath:
+          path: /opt/cni/bin
+      - name: etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: var-log
+        hostPath:
+          path: /var/log
+      - name: netns
+        hostPath:
+          path: /var/run/netns
+      - name: proc
+        hostPath:
+          path: /proc/

--- a/graph/graph-manager.go
+++ b/graph/graph-manager.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"strings"
 	"sync"
 
 	log "github.com/sirupsen/logrus"
@@ -115,6 +116,10 @@ func (manager *graphManager) doPreliminaryChecks(obj interface{}) {
 			}
 			log.Infof("Recovered deleted object '%s' from tombstone", ns.Name)
 		}
+	}
+
+	if strings.HasPrefix(ns.Name, "kube-") {
+		return
 	}
 
 	//------------------------------------

--- a/graph/graph-manager.go
+++ b/graph/graph-manager.go
@@ -57,7 +57,7 @@ func (manager *graphManager) getInformer() cache.SharedIndexInformer {
 			return manager.clientset.CoreV1().Namespaces().Watch(options)
 		},
 	},
-		&core_v1.Pod{},
+		&core_v1.Namespace{},
 		0, //Skip resync
 		cache.Indexers{},
 	)

--- a/graph/graph-manager.go
+++ b/graph/graph-manager.go
@@ -118,7 +118,7 @@ func (manager *graphManager) doPreliminaryChecks(obj interface{}) {
 		}
 	}
 
-	if strings.HasPrefix(ns.Name, "kube-") {
+	if strings.HasPrefix(ns.Name, "kube-") || ns.Name == "default" {
 		return
 	}
 

--- a/graph/graph-manager.go
+++ b/graph/graph-manager.go
@@ -124,7 +124,7 @@ func (manager *graphManager) doPreliminaryChecks(obj interface{}) {
 	manager.lock.Lock()
 	defer manager.lock.Unlock()
 
-	inf, err := new(manager.clientset, obj)
+	inf, err := new(manager.clientset, ns)
 	if err != nil {
 		return
 	}

--- a/graph/infrastructure-handler.go
+++ b/graph/infrastructure-handler.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	log "github.com/sirupsen/logrus"
+	apps_v1 "k8s.io/api/apps/v1"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,7 +48,7 @@ func (handler *InfrastructureHandler) getDeploymentsInformer() cache.SharedIndex
 			return handler.clientset.AppsV1().Deployments(handler.name).Watch(options)
 		},
 	},
-		&core_v1.Pod{},
+		&apps_v1.Deployment{},
 		0, //Skip resync
 		cache.Indexers{},
 	)
@@ -75,7 +76,7 @@ func (handler *InfrastructureHandler) getServicesInformer() cache.SharedIndexInf
 			return handler.clientset.CoreV1().Services(handler.name).Watch(options)
 		},
 	},
-		&core_v1.Pod{},
+		&core_v1.Service{},
 		0, //Skip resync
 		cache.Indexers{},
 	)

--- a/graph/infrastructure-handler.go
+++ b/graph/infrastructure-handler.go
@@ -26,8 +26,9 @@ type InfrastructureHandler struct {
 func new(clientset kubernetes.Interface, namespace *core_v1.Namespace) (Infrastructure, error) {
 	//	the handler
 	inf := &InfrastructureHandler{
-		name:   namespace.Name,
-		labels: namespace.Labels,
+		name:      namespace.Name,
+		labels:    namespace.Labels,
+		clientset: clientset,
 	}
 
 	deploymentsInformer := inf.getDeploymentsInformer()

--- a/graph/infrastructure-handler.go
+++ b/graph/infrastructure-handler.go
@@ -1,21 +1,94 @@
 package graph
 
 import (
+	log "github.com/sirupsen/logrus"
+	core_v1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 type Infrastructure interface {
 }
 
 type InfrastructureHandler struct {
-	clientset kubernetes.Interface
-	name      string
-	labels    map[string]string
+	clientset           kubernetes.Interface
+	name                string
+	labels              map[string]string
+	deploymentsInformer cache.SharedIndexInformer
+	servicesInformer    cache.SharedIndexInformer
 }
 
-func new(clientset kubernetes.Interface, obj interface{}) (Infrastructure, error) {
+func new(clientset kubernetes.Interface, namespace *core_v1.Namespace) (Infrastructure, error) {
 	//	the handler
-	inf := &InfrastructureHandler{}
+	inf := &InfrastructureHandler{
+		name:   namespace.Name,
+		labels: namespace.Labels,
+	}
+
+	deploymentsInformer := inf.getDeploymentsInformer()
+	inf.deploymentsInformer = deploymentsInformer
+
+	servicesInformer := inf.getServicesInformer()
+	inf.servicesInformer = servicesInformer
 
 	return inf, nil
+}
+
+func (handler *InfrastructureHandler) getDeploymentsInformer() cache.SharedIndexInformer {
+	//	Get the informer
+	informer := cache.NewSharedIndexInformer(&cache.ListWatch{
+		ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+			return handler.clientset.AppsV1().Deployments(handler.name).List(options)
+		},
+		WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+			return handler.clientset.AppsV1().Deployments(handler.name).Watch(options)
+		},
+	},
+		&core_v1.Pod{},
+		0, //Skip resync
+		cache.Indexers{},
+	)
+
+	//	Set the events
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			log.Infoln("new deployment!")
+		},
+		UpdateFunc: func(old, new interface{}) {
+		},
+		DeleteFunc: func(obj interface{}) {
+		},
+	})
+	return informer
+}
+
+func (handler *InfrastructureHandler) getServicesInformer() cache.SharedIndexInformer {
+	//	Get the informer
+	informer := cache.NewSharedIndexInformer(&cache.ListWatch{
+		ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+			return handler.clientset.CoreV1().Services(handler.name).List(options)
+		},
+		WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+			return handler.clientset.CoreV1().Services(handler.name).Watch(options)
+		},
+	},
+		&core_v1.Pod{},
+		0, //Skip resync
+		cache.Indexers{},
+	)
+
+	//	Set the events
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			log.Infoln("new service!")
+		},
+		UpdateFunc: func(old, new interface{}) {
+		},
+		DeleteFunc: func(obj interface{}) {
+		},
+	})
+	return informer
 }

--- a/graph/infrastructure-handler.go
+++ b/graph/infrastructure-handler.go
@@ -20,6 +20,7 @@ type InfrastructureHandler struct {
 	labels              map[string]string
 	deploymentsInformer cache.SharedIndexInformer
 	servicesInformer    cache.SharedIndexInformer
+	stopWatching        chan struct{}
 }
 
 func new(clientset kubernetes.Interface, namespace *core_v1.Namespace) (Infrastructure, error) {
@@ -34,6 +35,12 @@ func new(clientset kubernetes.Interface, namespace *core_v1.Namespace) (Infrastr
 
 	servicesInformer := inf.getServicesInformer()
 	inf.servicesInformer = servicesInformer
+
+	stopWatching := make(chan struct{})
+
+	go deploymentsInformer.Run(stopWatching)
+	go servicesInformer.Run(stopWatching)
+	inf.stopWatching = stopWatching
 
 	return inf, nil
 }


### PR DESCRIPTION
The infrastructure handler is in charge of knowing stuff related to an infrastructure: the graph it belongs to, its deployments, its services and its pods